### PR TITLE
Persist makes up the transaction, flush actions it, the event is redu…

### DIFF
--- a/spec/Changeset/Event/ObjectRepositorySpec.php
+++ b/spec/Changeset/Event/ObjectRepositorySpec.php
@@ -37,7 +37,7 @@ class ObjectRepositorySpec extends ObjectBehavior
     function it_can_append_event_to_data_store(ObjectManager $manager, EventInterface $event)
     {
         $manager->persist($event)->shouldBeCalled();
-        $manager->flush($event)->shouldBeCalled();
+        $manager->flush()->shouldBeCalled();
 
         $this->append($event);
     }

--- a/src/Changeset/Event/ObjectRepository.php
+++ b/src/Changeset/Event/ObjectRepository.php
@@ -32,7 +32,7 @@ class ObjectRepository implements RepositoryInterface
     public function append(EventInterface $event)
     {
         $this->manager->persist($event);
-        $this->manager->flush($event);
+        $this->manager->flush();
     }
 
     public function getIterator(): \Iterator


### PR DESCRIPTION
Persist makes up the transaction, flush actions it, the event is redundant and worked previously because flush had no typehint. The flush method interface looks like flush(array $options = []) now, whereas before it was flush($options = []) which didn't complain about the $event variable passed.

Yay for libraries adopting php 7+ and telling us about these things 💯 